### PR TITLE
fix(gfi): gfi not working on wms layers (Musées)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "@maplibre/maplibre-gl-directions": "^0.5.0",
         "@turf/union": "^6.5.0",
         "chart.js": "^4.4.1",
-        "maplibre-gl": "^3.6.2"
+        "maplibre-gl": "^3.6.2",
+        "proj4": "^2.10.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.7",
@@ -8003,6 +8004,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA=="
+    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -9581,6 +9587,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "node_modules/proj4": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.10.0.tgz",
+      "integrity": "sha512-0eyB8h1PDoWxucnq88/EZqt7UZlvjhcfbXCcINpE7hqRN0iRPWE/4mXINGulNa/FAvK+Ie7F+l2OxH/0uKV36A==",
+      "dependencies": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.3.3"
+      }
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -12576,6 +12591,11 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true
+    },
+    "node_modules/wkt-parser": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.3.tgz",
+      "integrity": "sha512-ZnV3yH8/k58ZPACOXeiHaMuXIiaTk1t0hSUVisbO0t4RjA5wPpUytcxeyiN2h+LZRrmuHIh/1UlrR9e7DHDvTw=="
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "@maplibre/maplibre-gl-directions": "^0.5.0",
     "@turf/union": "^6.5.0",
     "chart.js": "^4.4.1",
-    "maplibre-gl": "^3.6.2"
+    "maplibre-gl": "^3.6.2",
+    "proj4": "^2.10.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.7",

--- a/src/html/alt-menu/parameterMenu.html
+++ b/src/html/alt-menu/parameterMenu.html
@@ -4,7 +4,7 @@
     <h3>Interface</h3>
   </div>
   <!-- INFO: dans le cas d'une demande par les utilisateurs d'autres systèmes de coordonnées.
-    Cf. https://github.com/IGNF/appli-mobile-geoportail/blob/b90f7c88735781d709eff7f075bd6caa176dd12e/src/js/coordinates.js-->
+    Cf. https://github.com/IGNF/appli-mobile-geoportail/blob/b90f7c88735781d709eff7f075bd6caa176dd12e/src/js/coordinates.js -->
   <!-- <div id="coordType">
     <h3>Système de référence</h3>
     <p><input type="radio" id="coordGeoBtn" name="coordRadio" value="latlng" checked><label for="coordGeoBtn">Géographique</label></p>


### PR DESCRIPTION
Utilisation du GFI correct pour le WMS.
Obligé de passer par des reporjections et des calculs de résolutions à se péter le crâne.
Le saviez vous ? Pour déterminer la tileMatrix WMTS, MapLibre fait l'opération suivante :
```js
tileMatrix = Matth.round(map.getZoom()) + 1
```