### PR TITLE
Bump Github Actions

### DIFF
--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Make envfile
         run: |
@@ -20,7 +20,7 @@ jobs:
           echo "signalement_url=${{ secrets.SIGNALEMENT_URL }}" >> .env
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -34,7 +34,7 @@ jobs:
         run: npx cap sync
 
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 17

--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -25,7 +25,7 @@ jobs:
           echo "signalement_url=${{ secrets.SIGNALEMENT_URL }}" >> .env
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -93,7 +93,7 @@ jobs:
           cd ios/App && xcodebuild -exportArchive -archivePath $GITHUB_WORKSPACE/ign.xcarchive -exportOptionsPlist $EXPORT_PLIST_PATH -exportPath $RUNNER_TEMP/export
 
       - name: Upload application
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app
           path: ${{ runner.temp }}/export/App.ipa

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install modules
       run: npm i
     - name: Run ESLint


### PR DESCRIPTION
Some warnings are present on CI/CD because you use old versions of actions. Some actions are deprecated because they use an older version of node JS

Changelogs of actions:
- https://github.com/actions/upload-artifact/releases
- https://github.com/actions/checkout/releases
- https://github.com/actions/setup-node/releases
- https://github.com/actions/setup-java/releases

Maybe I forgot to update some actions, I have only updated actions that I use regularly with no problem when I have migrated to the new versions.