### PR TITLE
Fix Android deprecations

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,8 +5,8 @@ android {
     compileSdk rootProject.ext.compileSdkVersion
     defaultConfig {
         applicationId "fr.ign.geoportail"
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdk rootProject.ext.minSdkVersion
+        targetSdk rootProject.ext.targetSdkVersion
         versionCode 30103
         versionName "3.1.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
With gradle 7.0 version, some attributes have changed:
- minSdkVersion become minSdk
- targetSdkVersion become targetSdk

More information here:
- https://developer.android.com/reference/tools/gradle-api/7.0/com/android/build/api/dsl/BaseFlavor#minsdk
- https://developer.android.com/reference/tools/gradle-api/7.0/com/android/build/api/dsl/ApplicationBaseFlavor#targetsdk
