### PR TITLE
feat: support opening geo: URIs on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
               <category android:name="android.intent.category.BROWSABLE" />
               <data android:scheme="https" android:host="cartes-ign.ign.fr" />
             </intent-filter>
-            <!-- Pour l'ouvertutre des fichiers en local -->
+            <!-- Pour l'ouverture des fichiers en local -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -68,6 +68,13 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.kml" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.kml" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.kml" />
+            </intent-filter>
+            <!-- Pour l'ouverture des geo: URIs -->
+            <intent-filter>
+              <action android:name="android.intent.action.VIEW" />
+              <category android:name="android.intent.category.DEFAULT" />
+              <category android:name="android.intent.category.BROWSABLE" />
+              <data android:scheme="geo" />
             </intent-filter>
             <!-- Pour les pièces jointes -->
             <intent-filter>

--- a/src/js/event-listeners.js
+++ b/src/js/event-listeners.js
@@ -302,7 +302,8 @@ function addListeners() {
   // Partage par liens
   App.addListener("appUrlOpen", (e) => {
     if (e.url) {
-      if (e.url.split("://")[0] === "https") {
+      const [urlScheme, urlHostAndParams] = e.url.split(":");
+      if (urlScheme === "https") {
         const urlParams = new URLSearchParams(e.url.split("?")[1]);
         if (urlParams.get("lng") && urlParams.get("lat")) {
           while (Globals.backButtonState.split("-")[0] !== "default") {
@@ -359,6 +360,17 @@ function addListeners() {
                 .addTo(map);
             });
           }
+        }
+      } else if (urlScheme === "geo") {
+        const [urlHost, urlParamsString] = urlHostAndParams.split("?");
+        const urlParams = new URLSearchParams(urlParamsString);
+        let [lat, lng] = (urlParams.get("q") || "").split(",").map(parseFloat);
+        if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+          [lat, lng] = urlHost.split(",").map(parseFloat);
+        }
+        if (Number.isFinite(lat) && Number.isFinite(lng)) {
+          const zoom = parseFloat(urlParams.get("z")) || map.getZoom();
+          map.flyTo({zoom: zoom, center: { lng, lat }});
         }
       }
     }


### PR DESCRIPTION
### Motivation

Be able to open geo: URI from the web or share a location from another app (e.g. OsmAnd) with Cartes IGN.

Fixes: #164 

before:

<img width="256" height="540" alt="Screenshot_20250820_172628-540" src="https://github.com/user-attachments/assets/62f36480-3406-4776-a39c-fdb3f7389ad9" />

after:

<img width="256" height="540" alt="Screenshot_20250820_172741-540" src="https://github.com/user-attachments/assets/a406341a-7d61-4ddf-b89a-b78db63d5030" />

### Implementation

- Add intent filter for geo: URIs.
- Add parsing of geo: URIs to the code that parses `https://cartes-ign.ign.fr` URIs.

### How to test:

You can run the app in emulator and use `adb` to simulate a geo: URI being shared with Cartes IGN:

```shell
adb -s emulator-5554 shell am start -W -a android.intent.action.VIEW -d 'geo:43.6045,-1.444?z=13' fr.ign.geoportail
adb -s emulator-5554 shell am start -W -a android.intent.action.VIEW -d 'geo:0,0?q=43.6045,-1.444' fr.ign.geoportail
```