### PR TITLE
refactor(android): move getSharedFileUrl onto a dedicated bridge class

### DIFF
--- a/android/app/src/main/java/fr/ign/geoportail/MainActivity.java
+++ b/android/app/src/main/java/fr/ign/geoportail/MainActivity.java
@@ -30,7 +30,7 @@ public class MainActivity extends BridgeActivity {
         webview.setOverScrollMode(WebView.OVER_SCROLL_NEVER);
 
         webview.getSettings().setJavaScriptEnabled(true);
-        webview.addJavascriptInterface(this, "AndroidInterface");
+        webview.addJavascriptInterface(new AndroidInterface(), "AndroidInterface");
 
         handleShareIntent(getIntent());
     }
@@ -58,8 +58,10 @@ public class MainActivity extends BridgeActivity {
         }
     }
 
-    @android.webkit.JavascriptInterface
-    public String getSharedFileUrl() {
-        return lastHandledUri;
+    private final class AndroidInterface {
+        @android.webkit.JavascriptInterface
+        public String getSharedFileUrl() {
+            return lastHandledUri;
+        }
     }
 }


### PR DESCRIPTION
Closes #191.

`MainActivity.onStart()` registers the Activity itself as the JS bridge:


`webview.addJavascriptInterface(this, "AndroidInterface");`


and the bridge entry point lives on the Activity. Only `@JavascriptInterface` annotated methods are visible to JS on API 17+, so this is not a runtime regression. The change just confines the JS-visible surface to a small intent-limited class so the Activity does not also have to be the bridge.

### Change

Move `getSharedFileUrl` into a private `AndroidInterface` inner class and hand a fresh instance to `addJavascriptInterface`. JS contract is unchanged (`window.AndroidInterface.getSharedFileUrl()`).