### PR TITLE
fix(all): scroll impossible

### DIFF
--- a/src/css/layer-catalogue.css
+++ b/src/css/layer-catalogue.css
@@ -119,6 +119,7 @@
   flex-direction: row;
   justify-content: flex-start;
   overflow-x: scroll;
+  overscroll-behavior: unset;
   scrollbar-width: none;  /* Firefox */
 }
 
@@ -210,6 +211,7 @@
   margin: 0 0 10px 0;
   position: relative;
   overflow-x: scroll;
+  overscroll-behavior: unset;
   height: 55px;
   display: flex;
   flex-direction: row;

--- a/src/css/position.css
+++ b/src/css/position.css
@@ -137,6 +137,7 @@
   align-items: center;
   margin: 18px 0 18px 0;
   overflow-x: scroll;
+  overscroll-behavior: unset;
   scrollbar-width: none;
 }
 

--- a/src/js/event-listeners.js
+++ b/src/js/event-listeners.js
@@ -390,9 +390,9 @@ function addListeners() {
       window.scrollY <= 1;
 
     if (atBottom && delta > 0) {
-      e.preventDefault();
       const positionContainer = document.getElementById("positionContainer");
-      if (positionContainer) {
+      if (positionContainer && positionContainer.offsetParent !== null) {
+        e.preventDefault();
         positionContainer.classList.add("tabScrolledMax");
         positionContainer.scrollTop += delta;
       }


### PR DESCRIPTION
> j'ai eu 2 retours via le CRM indiquant qu'il est impossible de faire défiler les itinéraires enregistrés dans la liste (quand tu en as plus que 5-6), sur Android.
J'ai testé sur 2 tels Android, et je constate le même problème.

> sur iPhone me dit qu'il doit aller sur le côté droit chercher l'ascenseur pour pouvoir descendre. S'il scrolle au milieu ça ne bouge pas...

Le souci vient d'un nouvel écouteur d'évènement introduit pour matcher avec la maquette, mais utile uniquement sur les iti géotrek. J'ai rendu l'écouteur d'évèneent plus spécifique, en mettant le prevent default à un meilleur endroit.

J'en ai profité pour améliorer le comportement du scroll : sur les éléments défilables horizontalement, le scroll était impossible au toucher, à cause de overscroll-behavior: none mise sur * (pour éviter les animations bizarres de rebond sur téléphone). j'unset cette propriété pour touts les éléments qui ont overflow-x: scroll.