### PR TITLE
fix(layer-manager): several issues

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -322,7 +322,15 @@ function app() {
   // En premier lieu : on ne garde que les layers bien présents dans l'appli (peut arriver lors d'un màj si on supprime ou remplace une couche)
   const newLayersDisplayed = [];
   Globals.layersDisplayed.forEach( (layer) => {
-    if ((layer.id in LayersConfig.thematicLayerSources) || (layer.id in LayersConfig.baseLayerSources) || (layer.id in LayersConfig.tempLayerSources)) {
+    if (
+      layer &&
+      typeof layer.id === "string" &&
+      (
+        layer.id in LayersConfig.thematicLayerSources ||
+        layer.id in LayersConfig.baseLayerSources ||
+        layer.id in LayersConfig.tempLayerSources
+      )
+    ) {
       newLayersDisplayed.push(layer);
     }
   });

--- a/src/js/layer-manager/layer-manager.js
+++ b/src/js/layer-manager/layer-manager.js
@@ -110,29 +110,12 @@ class LayerManager extends EventTarget {
           detail: e.detail
         })
       );
-      let layerInLayerDisplayed = false;
-      const layerOptions = {
-        id: e.detail.id,
-        opacity: e.detail.options.opacity,
-        visible: e.detail.options.visibility,
-        gray: e.detail.options.gray,
-        isTempLayer: LayersConfig.getTempLayers().map((layer) => layer.id).includes(e.detail.id),
-      };
-      for(let i = 0; i < Globals.layersDisplayed.length; i++) {
-        if (Globals.layersDisplayed[i] === e.detail.id) {
-          Globals.layersDisplayed[i] = layerOptions;
-          layerInLayerDisplayed = true;
-        }
-        if (Globals.layersDisplayed[i].id === e.detail.id) {
-          layerInLayerDisplayed = true;
-        }
-      }
-      if (!layerInLayerDisplayed) {
-        Globals.layersDisplayed.push(layerOptions);
-      }
+      this.#syncLayersDisplayed(e.detail.entries);
       var element = document.getElementById(e.detail.id);
-      element.classList.add("selectedLayer");
-      this.#updateLayersCounter(e.type);
+      if (element) {
+        element.classList.add("selectedLayer");
+      }
+      this.#updateLayersCounter();
     });
     this.layerSwitcher.addEventListener("removelayer", (e) => {
       /**
@@ -147,22 +130,12 @@ class LayerManager extends EventTarget {
           detail: e.detail
         })
       );
-      let index = -1;
-      for(let i = 0; i < Globals.layersDisplayed.length; i++) {
-        if (Globals.layersDisplayed[i].id === e.detail.id) {
-          index = i;
-          break;
-        }
-      }
-      if (index >= 0) {
-        Globals.layersDisplayed.splice(index, 1);
-      }
+      this.#syncLayersDisplayed(e.detail.entries);
       var element = document.getElementById(e.detail.id);
-      element.classList.remove("selectedLayer");
-      if (e.detail.error) {
-        return;
+      if (element) {
+        element.classList.remove("selectedLayer");
       }
-      this.#updateLayersCounter(e.type);
+      this.#updateLayersCounter();
     });
     this.layerSwitcher.addEventListener("movelayer", (e) => {
       /**
@@ -178,7 +151,7 @@ class LayerManager extends EventTarget {
           detail: e.detail
         })
       );
-      Globals.layersDisplayed.splice(e.detail.positions.new, 0, Globals.layersDisplayed.splice(e.detail.positions.old, 1)[0]);
+      this.#syncLayersDisplayed(e.detail.entries);
     });
     this.layerSwitcher.addEventListener("layervisibility", (e) => {
       /**
@@ -194,7 +167,22 @@ class LayerManager extends EventTarget {
           detail: e.detail
         })
       );
+      this.#syncLayersDisplayed(e.detail.entries);
     });
+  }
+
+  /**
+     * Synchronise les couches persistées avec l'état réel du gestionnaire.
+     */
+  #syncLayersDisplayed(entries = this.layerSwitcher.getLayersOrder()) {
+    const tempLayerIds = LayersConfig.getTempLayers().map((layer) => layer.id);
+    Globals.layersDisplayed = entries.map(([id, options]) => ({
+      id: id,
+      opacity: options.opacity,
+      visible: options.visibility,
+      gray: options.gray,
+      isTempLayer: options.isTempLayer || tempLayerIds.includes(id),
+    }));
   }
 
   /**
@@ -264,19 +252,13 @@ class LayerManager extends EventTarget {
 
   /**
      * Mise à jour du comtpeur de couches sur le gestionnaire de couches
-     * @param {*} type
      */
-  #updateLayersCounter(type) {
-    // cf. l'abonnement à l'ajout / suppression de couche
+  #updateLayersCounter() {
     var counter = document.getElementById("layer-switcher-number");
-    var value = parseInt(counter.textContent, 10);
-    if (type === "addlayer") {
-      value++;
+    if (!counter) {
+      return;
     }
-    if (type === "removelayer") {
-      value--;
-    }
-    counter.textContent = value;
+    counter.textContent = Object.keys(this.layerSwitcher.layers).length;
   }
 
   /**
@@ -284,9 +266,15 @@ class LayerManager extends EventTarget {
      */
   #getLayersAvailableCounter() {
     var counter = document.getElementById("layer-thematics-number");
-    var value = LayersConfig.getBaseLayers().length +
-                    LayersConfig.getThematicLayers().length;
-    counter.textContent = value;
+    if (!counter) {
+      return;
+    }
+    const layerIds = new Set([
+      ...LayersConfig.getBaseLayers(),
+      ...LayersConfig.getThematicLayers(),
+      ...LayersConfig.getTempLayers().map((layer) => layer.id),
+    ]);
+    counter.textContent = layerIds.size;
   }
 }
 

--- a/src/js/layer-manager/layer-switcher.js
+++ b/src/js/layer-manager/layer-switcher.js
@@ -87,6 +87,7 @@ class LayerSwitcher extends EventTarget {
        * }
        */
     this.layers = {};
+    this.pendingLayerIds = new Set();
 
     this.#render();
 
@@ -690,6 +691,10 @@ class LayerSwitcher extends EventTarget {
    */
   async addLayer(layerOptions) {
     const id = layerOptions.id;
+    if (!id || this.layers[id] || this.pendingLayerIds.has(id)) {
+      return;
+    }
+    this.pendingLayerIds.add(id);
     var props;
     if (layerOptions.isTempLayer) {
       props = LayersConfig.getTempLayerProps(id);
@@ -722,6 +727,9 @@ class LayerSwitcher extends EventTarget {
     this.#addLayerContainer(id);
     try {
       await this.#addLayerMap(id);
+      if (!this.layers[id]) {
+        return;
+      }
       this.#updatePosition(id);
       this.#setOpacity(id, layerOptions.opacity);
       if (layerOptions.gray) {
@@ -789,8 +797,12 @@ class LayerSwitcher extends EventTarget {
         }
       }
     } catch (e) {
-      this.layers[id].error = true;
+      if (this.layers[id]) {
+        this.layers[id].error = true;
+      }
       throw e;
+    } finally {
+      this.pendingLayerIds.delete(id);
     }
   }
 
@@ -801,6 +813,9 @@ class LayerSwitcher extends EventTarget {
      * @public
      */
   removeLayer(id, isTempLayer = false) {
+    if (!id || !this.layers[id] || this.pendingLayerIds.has(id)) {
+      return;
+    }
     // Comptage du nombre de fonds de plan affichés
     let nbBaseLayers = 0;
     // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
Fix de plusieurs issues :
Dans index.js, rend plus robuste la lecture des layers displayed pour éviter les erreurs de plantage au démarrage (écran blanc)
Dans le layer manager, affiche le nombre correct de layers disponibles (avant 33, maintenant 28, à cause de la duplication des thématiques (été + tourisme par exemple))
Dans le layer manager, empêche le compteur de s'emballer quand on clique à toute vitesse sur un layer, et évite les erreurs si en cliquant comme ça on ajoute 2x le même layer maplibre