### PR TITLE
fix(fullscreen): several issues

### DIFF
--- a/src/css/map.css
+++ b/src/css/map.css
@@ -59,6 +59,14 @@
   position: fixed;
 }
 
+#map.css-fullscreen {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 20000;
+}
+
 .mapRLT {
   height: 100vh;
 }

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -91,22 +91,43 @@ const addControls = () => {
       unit: "metric"
     }), "bottom-left");
 
-    // contrôle fullscreen
-    const fullScreenCtrl = new maplibregl.FullscreenControl();
-    map.addControl(fullScreenCtrl, "bottom-right");
-    DOM.$fullScreenBtn = document.querySelector(".maplibregl-ctrl-bottom-right > .maplibregl-ctrl");
-    const fullScreenBtnParent = document.querySelectorAll(".maplibregl-ctrl-bottom-right")[0];
-    fullScreenCtrl.on("fullscreenstart", () => {
-      DOM.$map.appendChild(DOM.$interactivityBtn);
-      DOM.$map.appendChild(DOM.$mapScale);
-      DOM.$map.appendChild(fullScreenBtnParent);
-      Globals.interactivityIndicator.hardDisable();
-    });
-    fullScreenCtrl.on("fullscreenend", () => {
-      DOM.$map.parentNode.parentNode.appendChild(DOM.$interactivityBtn);
-      DOM.$bottomButtons.appendChild(DOM.$mapScale);
-      DOM.$bottomButtons.appendChild(fullScreenBtnParent);
-      Globals.interactivityIndicator.enable();
+    // contrôle fullscreen CSS (l'API fullscreen native casse l'affichage edge-to-edge sur iOS)
+    const fullScreenBtnParent = document.createElement("div");
+    fullScreenBtnParent.className = "maplibregl-ctrl-bottom-right";
+    const fullScreenCtrl = document.createElement("div");
+    fullScreenCtrl.className = "maplibregl-ctrl";
+    const fullScreenBtn = document.createElement("button");
+    fullScreenBtn.type = "button";
+    fullScreenBtn.className = "maplibregl-ctrl-fullscreen";
+    fullScreenBtn.title = "Plein écran";
+    fullScreenBtn.setAttribute("aria-label", "Plein écran");
+    fullScreenCtrl.appendChild(fullScreenBtn);
+    fullScreenBtnParent.appendChild(fullScreenCtrl);
+    DOM.$bottomButtons.appendChild(fullScreenBtnParent);
+    DOM.$fullScreenBtn = fullScreenCtrl;
+
+    fullScreenBtn.addEventListener("click", () => {
+      const isFullscreen = DOM.$map.classList.toggle("css-fullscreen");
+      fullScreenBtn.classList.toggle("maplibregl-ctrl-shrink", isFullscreen);
+      fullScreenBtn.classList.toggle("maplibregl-ctrl-fullscreen", !isFullscreen);
+      fullScreenBtn.title = isFullscreen ? "Quitter le plein écran" : "Plein écran";
+      fullScreenBtn.setAttribute("aria-label", fullScreenBtn.title);
+      if (isFullscreen) {
+        Globals.backButtonState = `fullscreen-${Globals.backButtonState}`;
+        DOM.$map.appendChild(DOM.$interactivityBtn);
+        DOM.$map.appendChild(DOM.$mapScale);
+        DOM.$map.appendChild(fullScreenBtnParent);
+        Globals.interactivityIndicator.hardDisable();
+      } else {
+        if (Globals.backButtonState.startsWith("fullscreen-")) {
+          Globals.backButtonState = Globals.backButtonState.substring("fullscreen-".length);
+        }
+        DOM.$map.parentNode.parentNode.appendChild(DOM.$interactivityBtn);
+        DOM.$bottomButtons.appendChild(DOM.$mapScale);
+        DOM.$bottomButtons.appendChild(fullScreenBtnParent);
+        Globals.interactivityIndicator.enable();
+      }
+      map.resize();
     });
 
     // contrôle d'intéractivité de la carte

--- a/src/js/route-draw/route-draw.js
+++ b/src/js/route-draw/route-draw.js
@@ -679,7 +679,10 @@ class RouteDraw {
 
     // Pas d'autre étape s'il n'y a qu'un point (premier point)
     if (this.data.points.length < 2) {
-      if (Globals.backButtonState === "routeDraw") {
+      if (
+        Globals.backButtonState === "routeDraw"
+        || Globals.backButtonState === "fullscreen-routeDraw"
+      ) {
         this.#listeners();
       }
       // Enregistrement de l'état dans l'historique
@@ -691,7 +694,10 @@ class RouteDraw {
     // Enregistrement de l'état dans l'historique
     this.#saveState();
     // Affichage et réactivation de l'intéractivité si on est toujours dans le tracé d'itinéraire
-    if (Globals.backButtonState === "routeDraw") {
+    if (
+      Globals.backButtonState === "routeDraw"
+      || Globals.backButtonState === "fullscreen-routeDraw"
+    ) {
       this.#listeners();
     }
   }
@@ -731,7 +737,10 @@ class RouteDraw {
       this.#updateElevation();
       this.data.duration -= removedStep[0].properties.duration;
       this.data.distance -= removedStep[0].properties.distance;
-      if (Globals.backButtonState === "routeDraw") {
+      if (
+        Globals.backButtonState === "routeDraw"
+        || Globals.backButtonState === "fullscreen-routeDraw"
+      ) {
         this.__updateRouteInfo(this.data);
       }
       this.#updateSources();
@@ -740,7 +749,10 @@ class RouteDraw {
       this.#updateElevation();
       this.data.duration -= removedStep[0].properties.duration;
       this.data.distance -= removedStep[0].properties.distance;
-      if (Globals.backButtonState === "routeDraw") {
+      if (
+        Globals.backButtonState === "routeDraw"
+        || Globals.backButtonState === "fullscreen-routeDraw"
+      ) {
         this.__updateRouteInfo(this.data);
       }
       this.#updateSources();
@@ -909,7 +921,10 @@ class RouteDraw {
     if (computeElevation) {
       this.#updateElevation();
     }
-    if (Globals.backButtonState === "routeDraw") {
+    if (
+      Globals.backButtonState === "routeDraw"
+      || Globals.backButtonState === "fullscreen-routeDraw"
+    ) {
       this.__updateRouteInfo(this.data);
     }
   }
@@ -994,7 +1009,10 @@ class RouteDraw {
     this.data.points[indexEnd + 1] = point;
 
     this.#updateSources();
-    if (Globals.backButtonState === "routeDraw") {
+    if (
+      Globals.backButtonState === "routeDraw"
+      || Globals.backButtonState === "fullscreen-routeDraw"
+    ) {
       this.__updateRouteInfo(this.data);
     }
   }
@@ -1020,7 +1038,10 @@ class RouteDraw {
       }
     }
     this.data.elevationData = this.elevation.getData();
-    if (Globals.backButtonState === "routeDraw") {
+    if (
+      Globals.backButtonState === "routeDraw"
+      || Globals.backButtonState === "fullscreen-routeDraw"
+    ) {
       if (!this.data.isTrack) {
         this.data.duration = GisUtils.getHikeTimeScarfsRule(this.data.distance, this.data.elevationData.dplus, Globals.walkingSpeed);
       }
@@ -1107,7 +1128,10 @@ class RouteDraw {
    * enregistre l'état précédent dans l'historique et réinitialise les annulations
    */
   #saveState() {
-    if (Globals.backButtonState === "routeDraw") {
+    if (
+      Globals.backButtonState === "routeDraw"
+      || Globals.backButtonState === "fullscreen-routeDraw"
+    ) {
       DOM.$routeDrawCancel.classList.remove("inactive");
     }
     DOM.$routeDrawRestore.classList.add("inactive");

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -19,6 +19,10 @@ const onBackKeyDown = () => {
   const previousStates = Globals.backButtonState.split("-");
   const backState = Globals.backButtonState.split("-")[0];
   /* comportements custom */
+  if (backState === "fullscreen") {
+    DOM.$fullScreenBtn.querySelector("button").click();
+    return;
+  }
   if (backState == "default") {
     if (Globals.trackRecord.activeRecord) {
       App.minimizeApp();


### PR DESCRIPTION
N'utilise plus le controle maplibre fullscreen (et donc lapi HTML 5 fullscreen), utilise une règle css simple à la place.

Fix de :
- ios: perte de bord à bord à la sortie du fullscreen
- ios: message moche à l'affichage du fullscreen
- android: comportement du bouton retour après avoir activé le fullscreen