### PR TITLE
fix(routeDraw): geom from myaccount still displayed

### DIFF
--- a/src/js/my-account/my-account.js
+++ b/src/js/my-account/my-account.js
@@ -1002,10 +1002,10 @@ class MyAccount {
    * @param {*} route
    */
   showRouteDetails(route) {
-    if (!route.visible) {
-      route.visible = true;
+    if (route.visible) {
+      route.visible = false;
       this.#updateSources();
-      document.getElementById(`route-container_ID_${route.id}`).classList.remove("invisible");
+      document.getElementById(`route-container_ID_${route.id}`).classList.add("invisible");
     }
     let coordinates = [];
     route.data.steps.forEach((step) => {


### PR DESCRIPTION
Masque la géométrie issue de myaccount quand on l'affiche dans routeDraw

pour éviter :
<img width="469" height="664" alt="image" src="https://github.com/user-attachments/assets/b59e38f6-c3c7-4029-8eba-2af2e15d934b" />
