### PR TITLE
fix(carousel): remove the overlay swipe listeners of the previous carousel

### DIFF
--- a/src/js/utils/image-carousel.js
+++ b/src/js/utils/image-carousel.js
@@ -30,6 +30,8 @@ class ImageCarousel {
 
   _overlay = document.getElementsByTagName("img-overlay")[0];
 
+  static _overlaySwipeHandlers = null;
+
   constructor(container, imageSources = [], options = {}) {
     if (!container) {
       throw new Error("Container element is required");
@@ -529,18 +531,19 @@ class ImageCarousel {
    * @private
    */
   _setupOverlaySwipe() {
-    if (this.isSingleImage) return;
-
     const overlayImage = this._overlay.querySelector("#imgOverlayImage");
     if (!overlayImage) return;
 
-    // Remove existing swipe listeners if they exist
-    if (this._overlayTouchStartHandler) {
-      overlayImage.removeEventListener("touchstart", this._overlayTouchStartHandler);
+    // Remove the swipe listeners of the carousel that used the overlay before this one.
+    // The overlay is shared, so they are held on the class rather than on the instance, and
+    // they have to go even when the carousel about to open holds a single image.
+    if (ImageCarousel._overlaySwipeHandlers) {
+      overlayImage.removeEventListener("touchstart", ImageCarousel._overlaySwipeHandlers.touchStart);
+      overlayImage.removeEventListener("touchend", ImageCarousel._overlaySwipeHandlers.touchEnd);
+      ImageCarousel._overlaySwipeHandlers = null;
     }
-    if (this._overlayTouchEndHandler) {
-      overlayImage.removeEventListener("touchend", this._overlayTouchEndHandler);
-    }
+
+    if (this.isSingleImage) return;
 
     let startX = 0;
     let startY = 0;
@@ -590,6 +593,11 @@ class ImageCarousel {
 
     overlayImage.addEventListener("touchstart", this._overlayTouchStartHandler, { passive: true });
     overlayImage.addEventListener("touchend", this._overlayTouchEndHandler, { passive: true });
+
+    ImageCarousel._overlaySwipeHandlers = {
+      touchStart: this._overlayTouchStartHandler,
+      touchEnd: this._overlayTouchEndHandler,
+    };
   }
 
   /**


### PR DESCRIPTION
Corrige #201.

## Le défaut

`img-overlay` est un seul élément, partagé par tous les carrousels. Ses écouteurs `touchstart` et `touchend` étaient en revanche retirés par une référence portée par l'instance :

```js
if (this._overlayTouchStartHandler) {
  overlayImage.removeEventListener("touchstart", this._overlayTouchStartHandler);
}
```

Un nouveau carrousel n'a pas cette référence, celle du précédent, donc il ne retire rien. Les écouteurs de l'ancienne instance restent sur l'image et continuent de piloter la rando déjà fermée, avec sa propre liste d'images.

Le cas décrit dans l'issue le rend visible : une rando à une seule image sort de `_setupOverlaySwipe` avant toute suppression, donc rien n'est retiré, et le balayage sur son image exécute encore les écouteurs de la dernière rando à plusieurs images.

## Le correctif

Les deux fonctions sont gardées sur la classe plutôt que sur l'instance, et retirées avant le test sur l'image unique. Pour les boutons précédent, suivant, fermer et partager, le fichier résout déjà le même problème en clonant le nœud ; l'image du plein écran ne pouvait pas être clonée sans la recharger.

## Vérification

Le scénario de l'issue rejoué dans un navigateur, sur la vraie classe compilée par webpack, avec des `TouchEvent` réels :

| étape | avant | après |
|---|---|---|
| rando A (1 image) ouverte | A1 | A1 |
| rando B (3 images), balayage | B2 | B2 |
| retour rando A, balayage | **B3** | A1 |

Et quatre cas de non-régression, qui passent des deux côtés : balayage suivant et précédent après avoir consulté une autre rando à plusieurs images, bouclage sur la première image, boutons précédent et suivant.

`npx eslint src/js/utils/image-carousel.js` et `npm run build` sont propres.

J'ai lu que le `CONTRIBUTING` demande de passer par les issues. Vu que des correctifs extérieurs ont été fusionnés récemment, je propose celui-ci directement ; si vous préférez, je peux tout remettre dans #201 et vous laisser la main.
